### PR TITLE
Fix for crash on opening pref pane

### DIFF
--- a/QProgEdit/_qprogedit.py
+++ b/QProgEdit/_qprogedit.py
@@ -17,7 +17,7 @@ You should have received a copy of the GNU General Public License
 along with QProgEdit.  If not, see <http://www.gnu.org/licenses/>.
 """
 
-from qtpy import QtGui, QtCore, QtWidgets
+from qtpy import QtCore, QtWidgets
 from QProgEdit import QEditor, QEditorPrefs, QEditorFind
 
 class QProgEdit(QtWidgets.QWidget):
@@ -211,7 +211,8 @@ class QProgEdit(QtWidgets.QWidget):
 		else:
 			widget.setMaximumHeight(widget.bestHeight)
 		widget.show()
-		a = QtCore.QPropertyAnimation(widget, u'maximumHeight', widget)
+		a = QtCore.QPropertyAnimation(widget, 
+			QtCore.QByteArray().append('maximumHeight'), widget)
 		if not visible:
 			a.setStartValue(widget.bestHeight)
 			a.setEndValue(0)


### PR DESCRIPTION
The line

    QtCore.QByteArray().append('maximumHeight')

is quite ugly in my opinion, but after Googling a bit, I found this to be the most robust solution to work with the various Qt and Python versions that are around. Tested it on Qt4 + python2 and Qt5 + python 2 and 3, and all seem to work. (Maybe you also want to test it with Qt4 and python3 to be sure, but I don't expect this to break).